### PR TITLE
Support for stringFirst and stringLast aggregations.

### DIFF
--- a/lib/druid/aggregation.rb
+++ b/lib/druid/aggregation.rb
@@ -7,14 +7,15 @@ module Druid
                                          javascript cardinality hyperUnique
                                          doubleFirst doubleLast longFirst
                                          longLast floatFirst floatLast
-                                         thetaSketch] }
+                                         stringLast thetaSketch] }
 
     attr_accessor :name
     validates :name, presence: true
 
     class FieldnameValidator < ActiveModel::EachValidator
       TYPES = %w[count longSum doubleSum min max hyperUnique doubleFirst
-                 doubleLast longFirst longLast floatFirst floatLast].freeze
+                 doubleLast longFirst longLast floatFirst floatLast
+                 stringLast].freeze
       def validate_each(record, attribute, value)
         if TYPES.include?(record.type)
           record.errors.add(attribute, 'may not be blank') if value.blank?

--- a/lib/druid/aggregation.rb
+++ b/lib/druid/aggregation.rb
@@ -7,7 +7,7 @@ module Druid
                                          javascript cardinality hyperUnique
                                          doubleFirst doubleLast longFirst
                                          longLast floatFirst floatLast
-                                         stringLast thetaSketch] }
+                                         stringFirst stringLast thetaSketch] }
 
     attr_accessor :name
     validates :name, presence: true
@@ -15,7 +15,7 @@ module Druid
     class FieldnameValidator < ActiveModel::EachValidator
       TYPES = %w[count longSum doubleSum min max hyperUnique doubleFirst
                  doubleLast longFirst longLast floatFirst floatLast
-                 stringLast].freeze
+                 stringFirst stringLast].freeze
       def validate_each(record, attribute, value)
         if TYPES.include?(record.type)
           record.errors.add(attribute, 'may not be blank') if value.blank?

--- a/lib/druid/query.rb
+++ b/lib/druid/query.rb
@@ -394,7 +394,7 @@ module Druid
 
       ### aggregations
       %i[count long_sum double_sum min max hyper_unique double_first double_last
-         float_first float_last long_first long_last].each do |method_name|
+         float_first float_last long_first long_last string_last].each do |method_name|
         define_method method_name do |*metrics|
           metrics.flatten.compact.each do |metric|
             @query.aggregations << Aggregation.new({

--- a/lib/druid/query.rb
+++ b/lib/druid/query.rb
@@ -393,8 +393,9 @@ module Druid
       end
 
       ### aggregations
-      %i[count long_sum double_sum min max hyper_unique double_first double_last
-         float_first float_last long_first long_last string_last].each do |method_name|
+      %i[count long_sum double_sum min max hyper_unique
+         double_first double_last float_first float_last long_first long_last
+         string_first string_last].each do |method_name|
         define_method method_name do |*metrics|
           metrics.flatten.compact.each do |metric|
             @query.aggregations << Aggregation.new({

--- a/spec/lib/query_spec.rb
+++ b/spec/lib/query_spec.rb
@@ -139,7 +139,7 @@ describe Druid::Query do
     it 'raises an error when an invalid javascript function is used' do
       expect {
         @query.postagg { js('{ return a_with_b - a; }').as b }
-      }.to raise_error
+      }.to raise_error('Invalid Javascript function')
     end
 
     it 'build a post aggregation with hyperUniqueCardinality' do
@@ -330,7 +330,8 @@ describe Druid::Query do
   end
 
   describe '#first_last_aggregators' do
-    %w[doubleFirst doubleLast longFirst longLast floatFirst floatLast].each do |type|
+    %w[doubleFirst doubleLast longFirst longLast floatFirst floatLast
+       stringLast].each do |type|
       it "builds aggregations with '#{type}' type" do
         @query.send(type.underscore, :a, :b)
         expect(JSON.parse(@query.query.to_json)['aggregations']).to eq [

--- a/spec/lib/query_spec.rb
+++ b/spec/lib/query_spec.rb
@@ -331,7 +331,7 @@ describe Druid::Query do
 
   describe '#first_last_aggregators' do
     %w[doubleFirst doubleLast longFirst longLast floatFirst floatLast
-       stringLast].each do |type|
+       stringFirst stringLast].each do |type|
       it "builds aggregations with '#{type}' type" do
         @query.send(type.underscore, :a, :b)
         expect(JSON.parse(@query.query.to_json)['aggregations']).to eq [


### PR DESCRIPTION
These aggregation types are still under Druid development.

It works similar to the other last and first aggregations, but returning a string instead of a number.